### PR TITLE
Remove chef-sugar

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,4 @@ chef_version '>= 12'
 supports 'redhat'
 
 depends 'compat_resource', '~> 12.14'
-depends 'chef-sugar', '>= 3.4'
-depends 'chef-sugar', '<= 4.0.0'
 depends 'line', '~> 1.0'

--- a/resources/map_entry.rb
+++ b/resources/map_entry.rb
@@ -34,8 +34,11 @@ action :create do # rubocop:disable Metrics/BlockLength
 
   case new_resource.fstype
   when 'nfs4'
-    include_recipe 'chef-sugar'
-    debian? ? (package 'nfs-common') : (package 'nfs-utils')
+    if platform_family? 'debian'
+      package 'nfs-common'
+    else
+      package 'nfs-utils'
+    end
   else
     log 'NFS type not set or supported' do
       message 'NFS type not set or supported'


### PR DESCRIPTION
`debian?` can be replaced with `platform_family?` and thus remove the dependency on chef-sugar.