### PR TITLE
In `map_entry` use find_resource to conditionally create the `automaster_entry`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle
+/Gemfile.lock
 .cache
 .kitchen
 bin

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'foodcritic', '~> 11.4.0'
+gem 'foodcritic', '~> 16.2.0'
 gem 'rubocop', '~> 0.49.1'

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ namespace :style do
   require 'foodcritic'
   desc 'Run Chef style checks'
   FoodCritic::Rake::LintTask.new(:chef) do |f|
-    f.options =  { tags: ['~FC016'] }
+    f.options =  { tags: ['~FC116'] }
   end
 end
 

--- a/resources/map_entry.rb
+++ b/resources/map_entry.rb
@@ -11,7 +11,9 @@ property :options, String
 action :create do # rubocop:disable Metrics/BlockLength
   file new_resource.map
 
-  automaster_entry new_resource.mount_point do
+  # the automaster_entry may have already been created (with options)
+  # so only create it if it doesn't exist
+  find_resource(:automaster_entry, new_resource.mount_point) do
     map new_resource.map
   end
 


### PR DESCRIPTION
In `map_entry` use find_resource to create the `automaster_entry` only
if it does not exist. It may have been previously created with options
(i.e. timeout) and unconditionally creating it will cause the options
to be undone.