### PR TITLE
fix: add frozen_string_literal, update EOL platforms, add apt_update to test recipes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,18 @@ jobs:
     strategy:
       matrix:
         os:
-          - "amazonlinux-2"
-          - "debian-9"
-          - "debian-10"
-          - "centos-7"
-          - "centos-8"
-          - "ubuntu-1804"
-          - "ubuntu-2004"
+          - "almalinux-8"
+          - "almalinux-9"
+          - "amazonlinux-2023"
+          - "centos-stream-9"
+          - "debian-12"
+          - "fedora-latest"
+          - "oraclelinux-8"
+          - "oraclelinux-9"
+          - "rockylinux-8"
+          - "rockylinux-9"
+          - "ubuntu-2204"
+          - "ubuntu-2404"
         suite:
           - "auto-master"
           - "map-entry"

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -22,35 +22,10 @@ platforms:
       image: dokken/amazonlinux-2023
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-7
-    driver:
-      image: dokken/centos-7
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: centos-stream-8
-    driver:
-      image: dokken/centos-stream-8
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: centos-stream-9
     driver:
       image: dokken/centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
-
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-
-  - name: debian-10
-    driver:
-      image: dokken/debian-10
-      pid_one_command: /bin/systemd
-
-  - name: debian-11
-    driver:
-      image: dokken/debian-11
-      pid_one_command: /bin/systemd
 
   - name: debian-12
     driver:
@@ -60,16 +35,6 @@ platforms:
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: opensuse-leap-15
-    driver:
-      image: dokken/opensuse-leap-15
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-7
-    driver:
-      image: dokken/oraclelinux-7
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: oraclelinux-8
@@ -92,22 +57,12 @@ platforms:
       image: dokken/rockylinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-18.04
-    driver:
-      image: dokken/ubuntu-18.04
-      pid_one_command: /bin/systemd
-
-  - name: ubuntu-20.04
-    driver:
-      image: dokken/ubuntu-20.04
-      pid_one_command: /bin/systemd
-
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
       pid_one_command: /bin/systemd
 
-  - name: ubuntu-23.04
+  - name: ubuntu-24.04
     driver:
-      image: dokken/ubuntu-23.04
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -10,13 +10,18 @@ provisioner:
   chef_license: accept-no-persist
 
 platforms:
-  - name: debian-9
-  - name: debian-10
-  - name: ubuntu-18.04
-  - name: ubuntu-20.04
-  - name: centos-7
-  - name: centos-8
-  - name: amazonlinux-2
+  - name: almalinux-8
+  - name: almalinux-9
+  - name: amazonlinux-2023
+  - name: centos-stream-9
+  - name: debian-12
+  - name: fedora-latest
+  - name: oraclelinux-8
+  - name: oraclelinux-9
+  - name: rockylinux-8
+  - name: rockylinux-9
+  - name: ubuntu-22.04
+  - name: ubuntu-24.04
 
 verifier:
   name: inspec

--- a/resources/automaster_entry.rb
+++ b/resources/automaster_entry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 resource_name :automaster_entry
 provides :automaster_entry
 unified_mode true

--- a/resources/map_entry.rb
+++ b/resources/map_entry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 resource_name :map_entry
 provides :map_entry
 unified_mode true

--- a/resources/nfs.rb
+++ b/resources/nfs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 resource_name :nfs
 provides :nfs
 unified_mode true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'chefspec'
 require 'chefspec/berkshelf'
 

--- a/test/cookbooks/test/recipes/auto_master.rb
+++ b/test/cookbooks/test/recipes/auto_master.rb
@@ -1,3 +1,5 @@
+apt_update
+
 automaster_entry '/misc' do
   map '/etc/auto.misc'
 end

--- a/test/cookbooks/test/recipes/kitchen_sudoers.rb
+++ b/test/cookbooks/test/recipes/kitchen_sudoers.rb
@@ -1,3 +1,5 @@
+apt_update
+
 # Work around for the kitchen Verifier requiring TTY for sudo
 execute 'Set !require tty for kitchen user' do
   action :run

--- a/test/cookbooks/test/recipes/map_entry.rb
+++ b/test/cookbooks/test/recipes/map_entry.rb
@@ -1,3 +1,5 @@
+apt_update
+
 map_entry 'userhome' do
   fstype 'smb'
   location 'smbserver:export'

--- a/test/cookbooks/test/recipes/multi.rb
+++ b/test/cookbooks/test/recipes/multi.rb
@@ -1,3 +1,5 @@
+apt_update
+
 automaster_entry '/home' do
   map '/awesome_perl_script.pl'
   options 'nfsvers=3 --timeout=600'

--- a/test/cookbooks/test/recipes/nfs.rb
+++ b/test/cookbooks/test/recipes/nfs.rb
@@ -1,3 +1,5 @@
+apt_update
+
 nfs '/nfs/userhome' do
   server 'nfsserver'
   export 'export'


### PR DESCRIPTION
- Add `frozen_string_literal: true` to 4 files missing it
- Replace all EOL platforms with current non-EOL in kitchen.yml, kitchen.dokken.yml, and CI matrix
- Add bare `apt_update` to all test recipes for Dokken compatibility