### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
     permissions:
       actions: write
       checks: write
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Chef
         uses: actionshub/chef-install@3.0.1
       - name: Dokken

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,7 +7,7 @@ name: 'Validate PR'
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4
     permissions:
       pull-requests: read
     secrets: inherit

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,8 +17,8 @@ jobs:
       contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -7,7 +7,7 @@ name: 'Prevent file change'
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.4
     permissions:
       pull-requests: write
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.4
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-cookbook 'test', path: 'test/cookbooks/test'

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'autofs'
+
+run_list 'recipe[test::kitchen_sudoers]', 'recipe[test::auto_master]'
+
+cookbook 'autofs', path: '.'
+cookbook 'line', git: 'https://github.com/sous-chefs/line.git', branch: 'main'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -11,5 +11,5 @@ cookbook 'test', path: './test/cookbooks/test'
 Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
   recipe_name = File.basename(recipe, '.rb')
 
-  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+  named_run_list recipe_name.to_sym, 'recipe[test::kitchen_sudoers]', 'recipe[test::' + recipe_name + ']'
 end

--- a/chefignore
+++ b/chefignore
@@ -85,8 +85,6 @@ test/*
 
 # Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -28,18 +28,26 @@ verifier:
 
 suites:
   - name: auto-master
+    provisioner:
+      named_run_list: auto_master
     run_list:
       - recipe[test::kitchen_sudoers]
       - recipe[test::auto_master]
   - name: map-entry
+    provisioner:
+      named_run_list: map_entry
     run_list:
       - recipe[test::kitchen_sudoers]
       - recipe[test::map_entry]
   - name: multi
+    provisioner:
+      named_run_list: multi
     run_list:
       - recipe[test::kitchen_sudoers]
       - recipe[test::multi]
   - name: nfs
+    provisioner:
+      named_run_list: nfs
     run_list:
       - recipe[test::kitchen_sudoers]
       - recipe[test::nfs]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update CI/Copilot workflow references to current sous-chefs workflow/action versions
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec --format progress
- kitchen list