### PR TITLE
chore: bump sous-chefs lint-unit reusable workflow to @9.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@9.0.0
     permissions:
       actions: write
       checks: write

--- a/chefignore
+++ b/chefignore
@@ -83,8 +83,8 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
+# Dependency cache #
+####################
 cookbooks/*
 tmp
 


### PR DESCRIPTION
## Summary
- bump sous-chefs lint-unit reusable workflow to @9.0.0
- remove the remaining stale Berkshelf reference from chefignore
- keep the Policyfile migration from refreshed origin/main intact

## Validation
- chef install Policyfile.rb
- cookstyle
- chef exec rspec
- markdownlint-cli2 "**/*.md"
- yamllint .
- actionlint
- git diff --check
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen diagnose auto-master-ubuntu-2404
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test auto-master-ubuntu-2404 --destroy=always